### PR TITLE
Add GA4 snippet to React index

### DIFF
--- a/new-smile-guide/public/index.html
+++ b/new-smile-guide/public/index.html
@@ -25,6 +25,13 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>React App</title>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXX"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-XXXXXXX');
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## Summary
- add GA4 script and initialization to `new-smile-guide/public/index.html`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*