### PR TITLE
Highlight active links in header

### DIFF
--- a/new-smile-guide/src/components/Header.tsx
+++ b/new-smile-guide/src/components/Header.tsx
@@ -25,7 +25,7 @@ import PersonOutlineOutlinedIcon from '@mui/icons-material/PersonOutlineOutlined
 import SchoolOutlinedIcon from '@mui/icons-material/SchoolOutlined';
 import WorkspacePremiumOutlinedIcon from '@mui/icons-material/WorkspacePremiumOutlined';
 import LogoutOutlinedIcon from '@mui/icons-material/LogoutOutlined';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, NavLink, useLocation } from 'react-router-dom';
 
 // Navigation links
 const navLinks = [
@@ -45,6 +45,7 @@ const Header: React.FC = () => {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const theme = useTheme();
+  const location = useLocation();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const isLoggedIn = false; // This would be determined by your auth context
   const isAdmin = localStorage.getItem('isAdmin') === 'true';
@@ -202,14 +203,19 @@ const Header: React.FC = () => {
               .map((link) => (
                 <Button
                   key={link.title}
-                  component={RouterLink}
+                  component={NavLink}
                   to={link.path}
                   sx={{
                     my: 2,
                     mx: 1,
-                    color: 'text.primary',
                     display: 'block',
                     fontWeight: 500,
+                    color:
+                      location.pathname === link.path
+                        ? 'primary.main'
+                        : 'text.primary',
+                    textDecoration:
+                      location.pathname === link.path ? 'underline' : 'none',
                     '&:hover': {
                       color: 'primary.main',
                     },


### PR DESCRIPTION
## Summary
- use `NavLink` instead of `RouterLink` for header navigation
- style active header link with primary colour and underline

## Testing
- `npm test --silent` *(fails: react-scripts not found)*